### PR TITLE
Update alphapulldown.yaml

### DIFF
--- a/workflow/envs/alphapulldown.yaml
+++ b/workflow/envs/alphapulldown.yaml
@@ -14,7 +14,8 @@ dependencies:
   - pytest
   - importlib_metadata
   - hhsuite
-  - jax==0.4.23
-  - jaxlib=*=*cuda*
+  - pip
   - pip:
+    - jax==0.4.23
+    - jaxlib=*=*cuda*
     - alphapulldown==1.0.4


### PR DESCRIPTION
Add dependency on pip and move jax & jaxlib to be pip-installed.
Solves https://github.com/KosinskiLab/AlphaPulldownSnakemake/issues/28