### PR TITLE
docs: bump AF2/AF3 container examples to 2.4.0

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -86,9 +86,9 @@ structure_inference_unified_memory: true
 structure_inference_xla_mem_fraction: auto
 
 # Specify the backend by changing the prediction container
-# - "docker://kosinskilab/alphafold2:2.1.5" for AlphaFold2
-# - "docker://kosinskilab/alphafold3:2.1.5" for AlphaFold3
-# - "docker://kosinskilab/alphalink:2.1.5" for AlphaLink 
+# - "docker://kosinskilab/alphafold2:2.4.0" for AlphaFold2
+# - "docker://kosinskilab/alphafold3:2.4.0" for AlphaFold3
+# - "docker://kosinskilab/alphalink:2.1.5" for AlphaLink  (latest published alphalink tag)
 # (you can also use local singularity .sif files)
 # - "/path/to/my/container.sif"
 prediction_container: "docker://kosinskilab/alphafold3:latest"


### PR DESCRIPTION
Match the 2.4.0 release in the `config.yaml` prediction-container examples.

- `kosinskilab/alphafold2` and `kosinskilab/alphafold3` → `2.4.0` (both tags confirmed on Docker Hub).
- `kosinskilab/alphalink` kept at `2.1.5`: there is **no `2.4.0` alphalink build** (latest published numeric tag is `2.1.5`), so the example points at the latest valid tag and is annotated.

Comment-only change to `config/config.yaml`; the active `prediction_container` stays on `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)